### PR TITLE
Changed URIs of Thing to be independent of Thing name.

### DIFF
--- a/thingweb-client/src/test/java/de/thingweb/client/TestClientFactory.java
+++ b/thingweb-client/src/test/java/de/thingweb/client/TestClientFactory.java
@@ -70,7 +70,7 @@ public class TestClientFactory extends TestCase {
 		// events
 		assertTrue(!client.getThing().getEvents().isEmpty());
 		assertTrue(client.getThing().getEvents().get(0).getName().equals("stateChanged"));
-		assertTrue(client.getThing().getEvents().get(0).getValueType().equals("xsd:boolean"));
+		assertTrue(client.getThing().getEvents().get(0).getInputType().equals("xsd:boolean"));
 		
 		// TODO add more tests such as events, properties
 		

--- a/thingweb-common/src/main/java/de/thingweb/thing/Action.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Action.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 import de.thingweb.thing.Property.Builder;
 
-public class Action {
+public class Action extends Interaction {
 
     private final Map<String, String> params;
     private final String name;

--- a/thingweb-common/src/main/java/de/thingweb/thing/Action.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Action.java
@@ -134,5 +134,8 @@ public class Action extends Interaction {
                else
                        return new Action(name,params);
         }
+        public Event buildEvent() {
+        	return new Event(name,inputType,outputType, hrefs);
+        }
     }
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Content.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Content.java
@@ -28,14 +28,26 @@ public class Content {
 	
 	final byte[] content;
 	final MediaType mediaType;
+	final String mediaTypeEx;
 	
 	public Content(byte[] content, MediaType mediaType) {
 		this.content = content;
 		this.mediaType = mediaType;
+		this.mediaTypeEx = null;
+	}
+	
+	public Content(byte[] content, String mediaType) {
+		this.content = content;
+		this.mediaTypeEx = mediaType;
+		this.mediaType = MediaType.UNDEFINED;
 	}
 	
 	public MediaType getMediaType() {
 		return this.mediaType;
+	}
+
+	public String getMediaTypeEx() {
+		return this.mediaTypeEx;
 	}
 	
 	public byte[] getContent() {

--- a/thingweb-common/src/main/java/de/thingweb/thing/Content.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Content.java
@@ -29,6 +29,10 @@ public class Content {
 	final byte[] content;
 	final MediaType mediaType;
 	final String mediaTypeEx;
+	private String locationPath;
+	private ResponseType responseType = ResponseType.UNDEFINED;
+	
+	public enum ResponseType {CREATED, READ, UPDATED, DELETED, SUBSCRIBED, ERROR, UNDEFINED};
 	
 	public Content(byte[] content, MediaType mediaType) {
 		this.content = content;
@@ -52,6 +56,22 @@ public class Content {
 	
 	public byte[] getContent() {
 		return this.content;
+	}
+
+	public String getLocationPath() {
+		return locationPath;
+	}
+
+	public void setLocationPath(String locationPath) {
+		this.locationPath = locationPath;
+	}
+	
+	public ResponseType getResponseType(){
+		return responseType;
+	}
+	
+	public void setResponseType(ResponseType responseType){
+		this.responseType = responseType;
 	}
 	
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Event.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Event.java
@@ -3,66 +3,11 @@ package de.thingweb.thing;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Event extends Interaction {
-	
-	private final String name;
-	private final String valueType;
-	private final List<String> hrefs;
+public class Event extends Action {
 	 
-    protected Event(String name, String valueType, List<String> hrefs) {
-        this.name = name;
-        this.valueType = valueType;
-        this.hrefs = hrefs;
+    protected Event(String name, String inputType, String outputType, List<String> hrefs) {
+    	super(name,inputType,outputType,hrefs);
     }
-    
-    /**
-     * creates a Builder for an Event
-     * @param name the Name of the Event
-     * @return a {@link de.thingweb.thing.Event.Builder} for the action
-     * */
-    public static Event.Builder getBuilder(String name) {
-        return new Event.Builder(name);
-    }
-    
-	
-    public String getName() {
-        return name;
-    }
-    
-	public String getValueType() {
-		return valueType;
-	}
 
-	public List<String> getHrefs(){
-		return hrefs;
-	}
-	
-    public static class Builder {
 
-        private final String name;
-        private String valueType = "";
-        private List<String> hrefs = new ArrayList<String>();
-
-        private Builder(String name) {
-            this.name = name;
-        }
-
-        public Builder setValueType(String valueType) {
-            this.valueType = (valueType == null) ? "" : valueType;
-            return this;
-        }
-        
-        public Builder setHrefs(List<String> hrefs) {
-          this.hrefs = hrefs;
-          return this;
-        }
-
-        /**
-         * generate the event, finalize the Builder
-         * @return the constructed Event
-         */
-        public Event build() {
-           return new Event(name, valueType, hrefs);
-        }
-    }
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Event.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Event.java
@@ -3,7 +3,7 @@ package de.thingweb.thing;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Event {
+public class Event extends Interaction {
 	
 	private final String name;
 	private final String valueType;

--- a/thingweb-common/src/main/java/de/thingweb/thing/HyperMediaLink.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/HyperMediaLink.java
@@ -46,14 +46,15 @@ public class HyperMediaLink {
     @JsonProperty("mediaType")
     private String mediaType;
 
-    public HyperMediaLink(String rel, String href) {
-        this.rel = rel;
-        this.href = href;
+    public HyperMediaLink(String rel, String href){
+    	this(rel, href, null, null);
     }
 
     public HyperMediaLink(String rel, String href, String method, String mediaType) {
         this.rel = rel;
         this.href = href;
+        if(!this.href.startsWith("/") && !this.href.contains(":")) //TODO find a  better to handle relative links
+        	this.href = "/" + this.href;
         this.method = method;
         this.mediaType = mediaType;
     }

--- a/thingweb-common/src/main/java/de/thingweb/thing/HyperMediaLink.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/HyperMediaLink.java
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-package de.thingweb.servient.impl;
+package de.thingweb.thing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/thingweb-common/src/main/java/de/thingweb/thing/Interaction.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Interaction.java
@@ -9,9 +9,23 @@ import java.util.Observable;
 public class Interaction extends Observable {
 
 	private Metadata m_metadata = new Metadata();
+	private Object m_tag;
+	
 	
 	public Metadata getMetadata(){
 		return m_metadata;
 	}
+
+
+	public Object getTag() {
+		return m_tag;
+	}
+
+
+	public void setTag(Object m_tag) {
+		this.m_tag = m_tag;
+	}
+	
+	
 
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Interaction.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Interaction.java
@@ -1,0 +1,17 @@
+package de.thingweb.thing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Observable;
+
+public class Interaction extends Observable {
+
+	private Metadata m_metadata = new Metadata();
+	
+	public Metadata getMetadata(){
+		return m_metadata;
+	}
+
+}

--- a/thingweb-common/src/main/java/de/thingweb/thing/MediaType.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/MediaType.java
@@ -42,6 +42,10 @@ public enum MediaType {
 	APPLICATION_EXI("application/exi"),
 	/** application/json */
 	APPLICATION_JSON("application/json"),
+	/** application/gzip */
+	APPLICATION_GZIP("application/gzip"),
+	/** application/image */
+	APPLICATION_IMG_JPEG("image/jpeg"),
 	/** undefined/unknown */
 	UNDEFINED("undefined");
 	
@@ -53,6 +57,8 @@ public enum MediaType {
 		mediaTypes.put(APPLICATION_XML.mediaType, APPLICATION_XML);
 		mediaTypes.put(APPLICATION_EXI.mediaType, APPLICATION_EXI);
 		mediaTypes.put(APPLICATION_JSON.mediaType, APPLICATION_JSON);
+		mediaTypes.put(APPLICATION_GZIP.mediaType, APPLICATION_GZIP);
+		mediaTypes.put(APPLICATION_IMG_JPEG.mediaType, APPLICATION_IMG_JPEG);
 		// mediaTypes.put(UNDEFINED.mediaType, UNDEFINED);
 	}
 	

--- a/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
@@ -46,7 +46,7 @@ public class Metadata
    * or null if key does not exist
    */
   public String get(String key) {
-    return items.get(items).iterator().next();
+    return items.get(key).get(0);
   }
   
   public List<String> getAll(String key) {

--- a/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
@@ -14,11 +14,13 @@ import java.util.Map;
  */
 public class Metadata
 {
-  public final static String METADATA_ELEMENT_URIS = "uris";
-  public final static String METADATA_ELEMENT_ENCODINGS = "encodings";
-  
   private Map<String, List<String>> items = new HashMap<String, List<String>>();
+  private List<HyperMediaLink> associations = new ArrayList<>();
   
+  public List<HyperMediaLink> getAssociations(){
+	  return associations;
+  }
+ 
   public void add(String key, String value) {
     checkKey(key);
     items.get(key).add(value);
@@ -64,5 +66,5 @@ public class Metadata
       items.put(key, new ArrayList<String>());
     }
   }
-
+  
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Metadata.java
@@ -14,6 +14,8 @@ import java.util.Map;
  */
 public class Metadata
 {
+  public final static String METADATA_ELEMENT_URIS = "uris";
+  public final static String METADATA_ELEMENT_ENCODINGS = "encodings";
   
   private Map<String, List<String>> items = new HashMap<String, List<String>>();
   
@@ -27,6 +29,11 @@ public class Metadata
     for (String v : values) {
       items.get(key).add(v);
     }
+  }
+  
+  public void remove(String key){
+	  if(items.containsKey(key))
+		  items.remove(key);
   }
   
   /**
@@ -46,6 +53,10 @@ public class Metadata
   
   public boolean contains(String key) {
     return items.containsKey(key);
+  }
+  
+  public Map<String, List<String>> getItems(){
+	  return items;
   }
   
   private void checkKey(String key) {

--- a/thingweb-common/src/main/java/de/thingweb/thing/Property.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Property.java
@@ -34,7 +34,7 @@ import java.util.Observable;
 /**
  * This class is immutable.
  */
-public class Property extends Observable {
+public class Property extends Interaction {
 	/*
 	 * Implementation Note:
 	 * Thing relies on this class to be immutable for synchronization purposes!
@@ -47,10 +47,12 @@ public class Property extends Observable {
 	private final boolean m_isWritable;
 	private final List<String> m_hrefs;
 	
+	//TODO Experimental. Need to find a way to prevent recursion during async update.
+	public boolean isUnderAsyncUpdate = false;
 	
 
 	
-	protected Property(String name, String xsdType, boolean isReadable, boolean isWritable, String propertyType, List<String> hrefs) {
+	public Property(String name, String xsdType, boolean isReadable, boolean isWritable, String propertyType, List<String> hrefs) {
 		if (null == name) {
 			throw new IllegalArgumentException("name must not be null");
 		}
@@ -70,6 +72,7 @@ public class Property extends Observable {
 	@Override
 	public synchronized void setChanged() {
 		super.setChanged();
+		super.notifyObservers();
 	}
 
 	public String getName() {

--- a/thingweb-common/src/main/java/de/thingweb/thing/Property.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Property.java
@@ -45,24 +45,32 @@ public class Property extends Interaction {
 	private final String m_valueType;
 	private final boolean m_isReadable;
 	private final boolean m_isWritable;
+	private final boolean m_isObservable;
 	private final List<String> m_hrefs;
 	
 	//TODO Experimental. Need to find a way to prevent recursion during async update.
 	public boolean isUnderAsyncUpdate = false;
+	public boolean isClientObserving = false;
+	public boolean isSubscribed = false;
 	
 
 	
-	public Property(String name, String xsdType, boolean isReadable, boolean isWritable, String propertyType, List<String> hrefs) {
+	public Property(String name, String xsdType, boolean isReadable, boolean isWritable, boolean isObservable, String propertyType, List<String> hrefs) {
 		if (null == name) {
 			throw new IllegalArgumentException("name must not be null");
 		}
 		
-		this.m_valueType = xsdType;
+		m_valueType = xsdType;
 		m_name = name;
 		m_isReadable = isReadable;
 		m_isWritable = isWritable;
 		m_propertyType = propertyType;
 		m_hrefs = hrefs;
+		m_isObservable = isObservable;
+	}
+	
+	public Property(String name, String xsdType, boolean isReadable, boolean isWritable, String propertyType, List<String> hrefs) {
+		this(name, xsdType, isReadable, isWritable, false, propertyType, hrefs);
 	}
 
 	public static Property.Builder getBuilder(String name) {
@@ -86,6 +94,10 @@ public class Property extends Interaction {
 	public boolean isWritable() {
 		return m_isWritable;
 	}
+	
+	public boolean isObservable() {
+		return m_isObservable;
+	}
 
 	public String getValueType() {
 		return m_valueType;
@@ -103,6 +115,7 @@ public class Property extends Interaction {
 		private String name;
 		private boolean isReadable = true;
 		private boolean isWriteable = false;
+		private boolean isObservable = false;
 		private String xsdType = "xsd:string";
 		private String propertyType = null;
 		private List<String> hrefs = new ArrayList<>();
@@ -139,9 +152,14 @@ public class Property extends Interaction {
 			this.isWriteable = isWriteable;
 			return this;
 		}
+		
+		public Property.Builder setObservable(boolean isObservable) {
+			this.isObservable = isObservable;
+			return this;
+		}
 
 		public Property build() {
-			return new Property(name, xsdType, isReadable, isWriteable, propertyType, hrefs);
+			return new Property(name, xsdType, isReadable, isWriteable, isObservable, propertyType, hrefs);
 		}
 	}
 

--- a/thingweb-common/src/main/java/de/thingweb/thing/Thing.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Thing.java
@@ -28,6 +28,7 @@ package de.thingweb.thing;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 
 /**
@@ -48,7 +49,10 @@ public final class Thing {
 
     private final String m_name;
     private final ThingMetadata m_metadata;
+    private Consumer<Object> m_deleteCallback;
+    private Object m_tag;
 
+    public Object servedThing;
     /**
      * Creates a new thing model.
      * <p>
@@ -66,6 +70,15 @@ public final class Thing {
         m_name = name;
         m_metadata = new ThingMetadata();
     }
+    
+
+	public Object getTag() {
+		return m_tag;
+	}
+
+	public void setTag(Object m_tag) {
+		this.m_tag = m_tag;
+	}    
 
     public String getName() {
         return m_name;
@@ -273,4 +286,12 @@ public final class Thing {
 
         return null;
     }
+
+	public Consumer<Object> getDeleteCallback() {
+		return m_deleteCallback;
+	}
+
+	public void setDeleteCallback(Consumer<Object> m_deleteCallback) {
+		this.m_deleteCallback = m_deleteCallback;
+	}
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/Thing.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/Thing.java
@@ -47,7 +47,7 @@ public final class Thing {
 	 */
 
     private final String m_name;
-    private final Metadata m_metadata;
+    private final ThingMetadata m_metadata;
 
     /**
      * Creates a new thing model.
@@ -64,14 +64,14 @@ public final class Thing {
         }
 
         m_name = name;
-        m_metadata = new Metadata();
+        m_metadata = new ThingMetadata();
     }
 
     public String getName() {
         return m_name;
     }
 
-    public Metadata getMetadata() {
+    public ThingMetadata getMetadata() {
         return m_metadata;
     }
 

--- a/thingweb-common/src/main/java/de/thingweb/thing/ThingMetadata.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/ThingMetadata.java
@@ -7,15 +7,16 @@ public class ThingMetadata extends Metadata {
 
 	public final static String METADATA_ELEMENT_URIS = "uris";
 	public final static String METADATA_ELEMENT_ENCODINGS = "encodings";
+	public final static String METADATA_ELEMENT_CONTEXT = "@context";
 
-	private Map<String, String> contexts = new HashMap<String, String>();
+	//private Map<String, String> contexts = new HashMap<String, String>();
 
-	public void addContext(String key, String value) {
-		contexts.put(key, value);
-	}
+	//public void addContext(String key, String value) {
+	//	contexts.put(key, value);
+	//}
 
-	public Map<String, String> getContexts() {
-		return contexts;
-	}
+	//public Map<String, String> getContexts() {
+	//	return contexts;
+	//}
 
 }

--- a/thingweb-common/src/main/java/de/thingweb/thing/ThingMetadata.java
+++ b/thingweb-common/src/main/java/de/thingweb/thing/ThingMetadata.java
@@ -1,0 +1,21 @@
+package de.thingweb.thing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ThingMetadata extends Metadata {
+
+	public final static String METADATA_ELEMENT_URIS = "uris";
+	public final static String METADATA_ELEMENT_ENCODINGS = "encodings";
+
+	private Map<String, String> contexts = new HashMap<String, String>();
+
+	public void addContext(String key, String value) {
+		contexts.put(key, value);
+	}
+
+	public Map<String, String> getContexts() {
+		return contexts;
+	}
+
+}

--- a/thingweb-common/src/main/java/de/thingweb/util/encoding/ContentHelper.java
+++ b/thingweb-common/src/main/java/de/thingweb/util/encoding/ContentHelper.java
@@ -27,6 +27,7 @@
 package de.thingweb.util.encoding;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.thingweb.thing.Content;
@@ -113,6 +114,58 @@ public class ContentHelper {
         if (data.getContent().length == 0) return null;
         Map map = (Map) parse(data, Map.class);
         return map.get("value");
+    }
+    
+    public static String getValueStringFromJson(Content data) throws Exception {
+    	try{
+	        if (data.getContent().length == 0) return null;
+	        String strContent = new String(data.getContent());
+	        //JsonNode node = mapper.readTree(strContent);
+	        //String valuePart = node.get("value").toString();
+	        //return valuePart;
+	        return strContent;
+    	}catch(Exception e){
+    		throw e;
+    	}
+    }
+    
+    public static boolean isValidJSON(final String json) {
+    	return json.startsWith("{") || json.startsWith("[");
+    	/*
+        boolean valid = true;
+        try{ 
+        	ObjectMapper objectMapper = new ObjectMapper();
+        	objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            objectMapper.readTree(json);
+        } catch(Exception e){
+            valid = false;
+        }
+        return valid;
+        */
+    }
+    public static boolean isNumeric(String str)  
+    {  
+      try  
+      {  
+        double d = Double.parseDouble(str);  
+      }  
+      catch(NumberFormatException nfe)  
+      {  
+        return false;  
+      }  
+      return true;  
+    }
+    
+    public static Content makeStringValue(String jsonString){
+    	//boolean validJson = isValidJSON(jsonString);
+    	//if(!validJson){
+    		//if(isNumeric(jsonString))
+    			//jsonString = "{\"value\":" + jsonString + "}";
+    		//else
+    		//	jsonString = "{\"value\":\"" + jsonString + "\"}";
+    	//}
+        byte[] bytes = jsonString.getBytes();
+        return new Content(bytes, de.thingweb.thing.MediaType.APPLICATION_JSON);
     }
 
     public static Content makeJsonValue(Object data) {

--- a/thingweb-parser/build.gradle
+++ b/thingweb-parser/build.gradle
@@ -25,10 +25,10 @@
 dependencies {
 	compile 'com.github.fge:json-schema-validator:2.2.6'
 	compile 'com.github.jsonld-java:jsonld-java:0.8.2'
-    compile group: 'com.siemens.ct.exi', name: 'exificient-for-json', version: '0.9.6a-SNAPSHOT', changing: true
+    compile group: 'com.siemens.ct.exi', name: 'exificient-for-json', version: '0.9.6', changing: true
     // compile 'com.siemens.ct.exi:exificient-for-json:0.9.6-SNAPSHOT'
-	// compile 'com.siemens.ct.exi:exificient:0.9.6-SNAPSHOT'
-	// compile 'com.siemens.ct.exi:exificient-for-json:0.9.6a-SNAPSHOT'
+	//compile 'com.siemens.ct.exi:exificient:0.9.6'
+	//compile 'com.siemens.ct.exi:exificient-for-json:0.9.6a-SNAPSHOT'
 	// compile 'org.glassfish:javax.json:1.0.4' // needed till exificient-for-json resolving works
 
     compile project(":thingweb-common")

--- a/thingweb-parser/src/main/java/de/thingweb/desc/ThingDescriptionParser.java
+++ b/thingweb-parser/src/main/java/de/thingweb/desc/ThingDescriptionParser.java
@@ -173,10 +173,20 @@ public class ThingDescriptionParser
   // TODO set as private (and check it is not called elsewhere)
   public static ObjectNode toJsonObject(Thing thing) {
     JsonNodeFactory factory = new JsonNodeFactory(false);
-
+    ArrayNode contexts = factory.arrayNode();
+    
     ObjectNode td = factory.objectNode();
-    td.put("@context", WOT_TD_CONTEXT);
+    //td.put("@context", WOT_TD_CONTEXT);
+    contexts.add(WOT_TD_CONTEXT);
+    Map<String, String> additionalContexts = thing.getMetadata().getContexts();
+    for(String key : additionalContexts.keySet()){
+	    ObjectNode context = factory.objectNode();
+	    context.put(key, additionalContexts.get(key));
+	    contexts.add(context);
+    }
+    td.put("@context", contexts);
     td.put("name", thing.getName());
+    td.putPOJO("associations", thing.getMetadata().getAssociations());
     
     Metadata metadata = thing.getMetadata();
     Map<String, List<String>> metadataItems = metadata.getItems();
@@ -222,7 +232,8 @@ public class ThingDescriptionParser
       } else if (prop.getHrefs().size() == 1) {
         p.put("hrefs", factory.textNode(prop.getHrefs().get(0)));
       }
-
+      if(prop.getMetadata().getAssociations().size() > 0)
+    	  p.putPOJO("associations", prop.getMetadata().getAssociations());
       properties.add(p);
     }
     td.put("properties", properties);
@@ -253,19 +264,21 @@ public class ThingDescriptionParser
       } else if (action.getHrefs().size() == 1) {
         a.put("hrefs", factory.textNode(action.getHrefs().get(0)));
       }
-
+      if(action.getMetadata().getAssociations().size() > 0)
+    	  a.putPOJO("associations", action.getMetadata().getAssociations());
       actions.add(a);
     }
     td.put("actions", actions);
 
     ArrayNode events = factory.arrayNode();
     for (Event event : thing.getEvents()) {
-      ObjectNode a = factory.objectNode();
-      a.put("name", event.getName());
+      ObjectNode n = factory.objectNode();
+      n.put("name", event.getName());
 
       if (!event.getValueType().isEmpty()) {
         ObjectNode in = factory.objectNode();
         in.put("valueType", event.getValueType());
+        n.put("inputData", in);
       }
 
       if (event.getHrefs().size() > 1) {
@@ -273,14 +286,14 @@ public class ThingDescriptionParser
         for (String href : event.getHrefs()) {
           hrefs.add(href);
         }
-        a.put("hrefs", hrefs);
+        n.put("hrefs", hrefs);
       } else if (event.getHrefs().size() == 1) {
-        a.put("hrefs", factory.textNode(event.getHrefs().get(0)));
+        n.put("hrefs", factory.textNode(event.getHrefs().get(0)));
       }
 
-      events.add(a);
+      events.add(n);
     }
-    td.put("events", actions);
+    td.put("events", events);
 
     return td;
   }

--- a/thingweb-parser/src/main/java/de/thingweb/desc/ThingDescriptionParser.java
+++ b/thingweb-parser/src/main/java/de/thingweb/desc/ThingDescriptionParser.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -60,6 +61,7 @@ import com.siemens.ct.exi.json.EXIforJSONParser;
 
 import de.thingweb.thing.Action;
 import de.thingweb.thing.Event;
+import de.thingweb.thing.Metadata;
 import de.thingweb.thing.Property;
 import de.thingweb.thing.Thing;
 
@@ -175,7 +177,18 @@ public class ThingDescriptionParser
     ObjectNode td = factory.objectNode();
     td.put("@context", WOT_TD_CONTEXT);
     td.put("name", thing.getName());
-
+    
+    Metadata metadata = thing.getMetadata();
+    Map<String, List<String>> metadataItems = metadata.getItems();
+    
+    for(String key : metadataItems.keySet()){
+    	ArrayNode metadataElement = factory.arrayNode();
+        for (String e : thing.getMetadata().getAll(key)) {
+        	metadataElement.add(e);
+        }
+        td.put(key, metadataElement);
+    }
+/*
     if (thing.getMetadata().contains("encodings")) {
       ArrayNode encodings = factory.arrayNode();
       for (String e : thing.getMetadata().getAll("encodings")) {
@@ -192,7 +205,7 @@ public class ThingDescriptionParser
       // TODO array even if single value?
       td.put("uris", uris);
     }
-
+*/
     ArrayNode properties = factory.arrayNode();
     for (Property prop : thing.getProperties()) {
       ObjectNode p = factory.objectNode();

--- a/thingweb-server/src/main/java/de/thingweb/binding/AbstractRESTListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/AbstractRESTListener.java
@@ -31,7 +31,9 @@ import de.thingweb.security.TokenExpiredException;
 import de.thingweb.security.TokenRequirements;
 import de.thingweb.security.UnauthorizedException;
 import de.thingweb.thing.Content;
+import javafx.util.Pair;
 
+import java.util.List;
 import java.util.Observable;
 
 public class AbstractRESTListener extends Observable implements RESTListener {
@@ -66,7 +68,7 @@ public class AbstractRESTListener extends Observable implements RESTListener {
 	}
 
 	@Override
-	public void onPut(Content data) throws UnsupportedOperationException, IllegalArgumentException, RuntimeException {
+	public Content onPut(Content data) throws UnsupportedOperationException, IllegalArgumentException, RuntimeException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -79,4 +81,10 @@ public class AbstractRESTListener extends Observable implements RESTListener {
 	public void onDelete() {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public List<Pair<String, String>> getHeaders() {
+		return null;
+	}
+	
 }

--- a/thingweb-server/src/main/java/de/thingweb/binding/AbstractRESTListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/AbstractRESTListener.java
@@ -61,7 +61,7 @@ public class AbstractRESTListener extends Observable implements RESTListener {
 	}
 
 	@Override
-	public Content onGet() {
+	public Content onGet() throws Exception {
 		throw new UnsupportedOperationException();
 	}
 

--- a/thingweb-server/src/main/java/de/thingweb/binding/RESTListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/RESTListener.java
@@ -30,7 +30,9 @@ import de.thingweb.security.SecurityTokenValidator;
 import de.thingweb.security.TokenExpiredException;
 import de.thingweb.security.UnauthorizedException;
 import de.thingweb.thing.Content;
+import javafx.util.Pair;
 
+import java.util.List;
 import java.util.Observer;
 
 public interface RESTListener {
@@ -43,12 +45,14 @@ public interface RESTListener {
 
 	Content onGet() throws UnsupportedOperationException, RuntimeException, Exception;
 
-	void onPut(Content data) throws UnsupportedOperationException, IllegalArgumentException, RuntimeException;
+	Content onPut(Content data) throws UnsupportedOperationException, IllegalArgumentException, RuntimeException;
 	
 	Content onPost(Content data) throws SecurityException,UnsupportedOperationException, IllegalArgumentException, RuntimeException;
 	
 	void onDelete() throws SecurityException ,UnsupportedOperationException,  RuntimeException;
 
 	void addObserver(Observer o);
+	
+	List<Pair<String, String>> getHeaders();
 
 }

--- a/thingweb-server/src/main/java/de/thingweb/binding/RESTListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/RESTListener.java
@@ -41,7 +41,7 @@ public interface RESTListener {
 
 	void protectWith(SecurityTokenValidator validator);
 
-	Content onGet() throws UnsupportedOperationException, RuntimeException;
+	Content onGet() throws UnsupportedOperationException, RuntimeException, Exception;
 
 	void onPut(Content data) throws UnsupportedOperationException, IllegalArgumentException, RuntimeException;
 	

--- a/thingweb-server/src/main/java/de/thingweb/binding/ResourceBuilder.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/ResourceBuilder.java
@@ -29,6 +29,8 @@ package de.thingweb.binding;
 public interface ResourceBuilder {
 
 	void newResource(String url, RESTListener restListener);
+	
+	void removeResource(String url);
 
 	String getBase();
 

--- a/thingweb-server/src/main/java/de/thingweb/binding/coap/CoapBinding.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/coap/CoapBinding.java
@@ -50,7 +50,7 @@ public class CoapBinding implements Binding {
     public CoapBinding() {
         String hostname = null;
         try {
-            hostname = InetAddress.getLocalHost().getHostName();
+            hostname = InetAddress.getLocalHost().getHostAddress();
         } catch (UnknownHostException e) {
             hostname = "localhost";
         }

--- a/thingweb-server/src/main/java/de/thingweb/binding/coap/CoapBinding.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/coap/CoapBinding.java
@@ -98,6 +98,33 @@ public class CoapBinding implements Binding {
 
                 current.add(newRes);
             }
+			
+			@Override
+            public void removeResource(String url) {
+                String[] parts = url.split("/");
+                if(parts.length == 0) return;
+
+                Resource current = m_coapServer.getRoot();
+
+                for (int i = 0; i < parts.length - 1; i++) {
+                    if (parts[i].isEmpty()) {
+                        continue;
+                    }
+                    Resource child = current.getChild(parts[i]);
+                    current = child;
+                }
+
+                String lastPart = parts[parts.length - 1];
+                Resource existing = current.getChild(lastPart);
+                
+                while(true){
+                	Resource parent = existing.getParent();
+                	parent.remove(existing);
+                	if(parent.getChildren().size() != 0)
+                		break;
+                	existing = parent;
+                }               
+            }			
 
             @Override
             public String getBase() {

--- a/thingweb-server/src/main/java/de/thingweb/binding/coap/WotCoapResource.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/coap/WotCoapResource.java
@@ -38,6 +38,7 @@ import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.jose4j.json.internal.json_simple.JSONObject;
 
 import java.util.Observable;
 import java.util.Observer;
@@ -142,7 +143,11 @@ public class WotCoapResource extends CoapResource implements  Observer{
         } catch (UnsupportedOperationException e) {
             exchange.respond(CoAP.ResponseCode.METHOD_NOT_ALLOWED);
         } catch (Exception e) {
-            exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        	JSONObject errorObject = new JSONObject();
+        	errorObject.put("errorMessage", e.getMessage());
+        	String responsePayload = errorObject.toJSONString();
+        	//TODO Media type be must got from rest listener..
+        	exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR, responsePayload, MediaTypeRegistry.APPLICATION_JSON);
         }
     }
 

--- a/thingweb-server/src/main/java/de/thingweb/binding/coap/WotCoapResource.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/coap/WotCoapResource.java
@@ -186,9 +186,17 @@ public class WotCoapResource extends CoapResource implements  Observer{
             Content request = new Content(reqPayload, mt);
         	Content response = m_restListener.onPost(request);
         	int contentFormat = getCoapContentFormat(response.getMediaType());
-
-            //TODO: add Location Option to response
-        	exchange.respond(CoAP.ResponseCode.CREATED, response.getContent(), contentFormat);
+        	if(response.getLocationPath() != null)        		
+        		exchange.setLocationPath(response.getLocationPath());
+        	
+        	CoAP.ResponseCode responseCode = CoAP.ResponseCode.CREATED;
+        	
+        	if(response.getResponseType() == Content.ResponseType.UPDATED)
+        		responseCode = CoAP.ResponseCode.CHANGED;
+        	else if(response.getResponseType() == Content.ResponseType.ERROR)
+        		responseCode = CoAP.ResponseCode.NOT_ACCEPTABLE;
+        	
+        	exchange.respond(responseCode, response.getContent(), contentFormat);
         } catch (UnsupportedOperationException e) {
             exchange.respond(CoAP.ResponseCode.METHOD_NOT_ALLOWED);
         } catch (IllegalArgumentException e) {

--- a/thingweb-server/src/main/java/de/thingweb/binding/http/NanoHttpServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/http/NanoHttpServer.java
@@ -34,6 +34,8 @@ import de.thingweb.thing.Content;
 import de.thingweb.thing.MediaType;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Response.Status;
+
+import org.jose4j.json.internal.json_simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +137,10 @@ public class NanoHttpServer extends NanoHTTPD  implements ResourceBuilder {
 			return addCORSHeaders(new Response(Status.BAD_REQUEST, MIME_PLAINTEXT, e.toString()));
 		} catch (Exception e) {
 			log.error("callback raised error", e);
-			return addCORSHeaders(new Response(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, e.toString()));
+        	JSONObject errorObject = new JSONObject();
+        	errorObject.put("errorMessage", e.getMessage());
+        	String responsePayload = errorObject.toJSONString();
+			return addCORSHeaders(new Response(Response.Status.INTERNAL_ERROR, "application/json", responsePayload));
 		}
 
 	}
@@ -177,7 +182,7 @@ public class NanoHttpServer extends NanoHTTPD  implements ResourceBuilder {
 
     @Override
     public void newResource(String url, RESTListener restListener) {
-        resmap.put(url.toLowerCase(),restListener);
+        resmap.put("/" + url.toLowerCase(),restListener);
     }
 
 	@Override

--- a/thingweb-server/src/main/java/de/thingweb/binding/http/NanoHttpServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/http/NanoHttpServer.java
@@ -64,7 +64,7 @@ public class NanoHttpServer extends NanoHTTPD  implements ResourceBuilder {
 
 	public NanoHttpServer(int port) throws IOException {
 		super(port);
-		String hostname = InetAddress.getLocalHost().getHostName();
+		String hostname = InetAddress.getLocalHost().getHostAddress();
 		baseuri = String.format("http://%s:%s",hostname, port);
 		resmap.put(WellKnownListener.WELL_KNOWN_URL, wellKnownListener);
 	}

--- a/thingweb-server/src/main/java/de/thingweb/binding/http/WellKnownListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/binding/http/WellKnownListener.java
@@ -1,0 +1,42 @@
+package de.thingweb.binding.http;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.thingweb.binding.AbstractRESTListener;
+import de.thingweb.thing.Content;
+import de.thingweb.thing.HyperMediaLink;
+import de.thingweb.util.encoding.ContentHelper;
+import javafx.util.Pair;
+
+public class WellKnownListener extends AbstractRESTListener {
+	
+	public static final String WELL_KNOWN_URL = "/.well-known/wot";
+	private List<HyperMediaLink> links = new ArrayList<>();
+	
+	@Override
+	public Content onGet() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		String json = mapper.writer().writeValueAsString(links);
+		return ContentHelper.makeStringValue(json);
+	}
+	
+	@Override
+	public List<Pair<String, String>> getHeaders() {
+		if(links.size() == 0)
+			return null;
+		ArrayList<Pair<String, String>> headers = new ArrayList<>();
+		String value = "";
+		for(HyperMediaLink link : links)
+			value += "<" + link.getHref() + ">;rel=thing ";
+		headers.add(new Pair<String,String>("Link", value));
+		return headers;
+	}
+	
+	public void addLink(HyperMediaLink link){
+		links.add(link);
+	}
+
+}

--- a/thingweb-server/src/main/java/de/thingweb/servient/Defines.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/Defines.java
@@ -29,7 +29,7 @@ public class Defines {
 
     public static final String BASE_URL = "/";
 
-    public static final String BASE_THING_URL = BASE_URL + "things/";
+    //public static final String BASE_THING_URL = BASE_URL + "things/";
 
     public static final String BASE_TD_URL = BASE_URL + "tds/";
 

--- a/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
@@ -65,7 +65,7 @@ public interface ThingInterface {
      */
     void setProperty(String propertyName, Object value);
 
-    void updateProperty(Property property, Object value);
+    Object updateProperty(Property property, Object value);
 
     Object getProperty(Property property);
 
@@ -87,7 +87,7 @@ public interface ThingInterface {
 
     void onPropertyRead(Consumer<Object> callback);
     
-    void onPropertyUpdate(BiConsumer<Object, Object> callback);
+    void onPropertyUpdate(BiFunction<Object, Object, Object> callback);
     
     void onActionInvoke(BiFunction<Object, Object, Object> callback);
 

--- a/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
@@ -27,6 +27,7 @@ package de.thingweb.servient;
 import de.thingweb.thing.Action;
 import de.thingweb.thing.Property;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -84,4 +85,6 @@ public interface ThingInterface {
     void onPropertyRead(Consumer<Object> callback);
 
     String getName();
+    
+    List<String> getURIs();
 }

--- a/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/ThingInterface.java
@@ -28,6 +28,8 @@ import de.thingweb.thing.Action;
 import de.thingweb.thing.Property;
 
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -63,6 +65,7 @@ public interface ThingInterface {
      */
     void setProperty(String propertyName, Object value);
 
+    void updateProperty(Property property, Object value);
 
     Object getProperty(Property property);
 
@@ -83,6 +86,10 @@ public interface ThingInterface {
     void onUpdate(String propertyName, Consumer<Object> callback);
 
     void onPropertyRead(Consumer<Object> callback);
+    
+    void onPropertyUpdate(BiConsumer<Object, Object> callback);
+    
+    void onActionInvoke(BiFunction<Object, Object, Object> callback);
 
     String getName();
     

--- a/thingweb-server/src/main/java/de/thingweb/servient/ThingServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/ThingServer.java
@@ -38,6 +38,8 @@ import java.util.Set;
 public interface ThingServer {
 
     ThingInterface addThing(Thing thing);
+    
+    void removeThing(Thing thing);
 
     void rebindSec(String name, boolean enabled);
 

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
@@ -82,14 +82,14 @@ public class ActionListener extends AbstractRESTListener {
     public Content onPost(Content data) {
         Object param = null;
         //if(data.getMediaType().equals(MediaType.APPLICATION_JSON)) {
-            param = ContentHelper.getValueFromJson(data);
+           // param = ContentHelper.getValueFromJson(data);
         //} else if(data.getMediaType().equals(MediaType.TEXT_PLAIN)) {
             param = new String(data.getContent());
         //}
 
         log.debug("invoking {}", action.getName());
         Object response = servedThing.invokeAction(action, param);
-        return onGet();
+        return (Content)response;
         //return (Content)response;
         //return ContentHelper.wrap(response, MediaType.APPLICATION_JSON);
     }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
@@ -52,7 +52,7 @@ public class ActionListener extends AbstractRESTListener {
     public ActionListener(ServedThing servedThing, Action action) {
         this.action = action;
         this.servedThing = servedThing;
-        this.inputType = this.action.getParams().get("parm");
+        this.inputType = this.action.getInputType();//.getParams().get("parm");
     }
 
     @Override
@@ -61,33 +61,36 @@ public class ActionListener extends AbstractRESTListener {
     	List<HyperMediaLink> links = new ArrayList<>();
     	
     	links.add(new HyperMediaLink("invoke","_self","POST",inputType));
-    	links.add(new HyperMediaLink("parent","../"));
+    	//links.add(new HyperMediaLink("parent","../"));
     	
     	if(action.getMetadata().getAssociations().size() > 0)
     		links.addAll(action.getMetadata().getAssociations());
 
     	return HypermediaIndex.createContent(links);
     }
-
+/*
     @Override
-    public void onPut(Content data) {
+    public Content onPut(Content data) {
         log.warn("Action was called by PUT, which is a violation of the spec");
         Object param = ContentHelper.getValueFromJson(data);
         log.debug("invoking {}", action.getName());
-        servedThing.invokeAction(action, param);
+        Object result = servedThing.invokeAction(action, param);
+        return null;
     }
-
+*/
     @Override
     public Content onPost(Content data) {
         Object param = null;
-        if(data.getMediaType().equals(MediaType.APPLICATION_JSON)) {
+        //if(data.getMediaType().equals(MediaType.APPLICATION_JSON)) {
             param = ContentHelper.getValueFromJson(data);
-        } else if(data.getMediaType().equals(MediaType.TEXT_PLAIN)) {
+        //} else if(data.getMediaType().equals(MediaType.TEXT_PLAIN)) {
             param = new String(data.getContent());
-        }
+        //}
 
         log.debug("invoking {}", action.getName());
         Object response = servedThing.invokeAction(action, param);
-        return ContentHelper.wrap(response, MediaType.APPLICATION_JSON);
+        return onGet();
+        //return (Content)response;
+        //return ContentHelper.wrap(response, MediaType.APPLICATION_JSON);
     }
 }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ActionListener.java
@@ -29,8 +29,13 @@ package de.thingweb.servient.impl;
 import de.thingweb.binding.AbstractRESTListener;
 import de.thingweb.thing.Action;
 import de.thingweb.thing.Content;
+import de.thingweb.thing.HyperMediaLink;
 import de.thingweb.thing.MediaType;
 import de.thingweb.util.encoding.ContentHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,10 +58,15 @@ public class ActionListener extends AbstractRESTListener {
     @Override
     public Content onGet() {
         //TODO manage executions in statecontainer and add links to executions
-        return HypermediaIndex.createContent(
-                new HyperMediaLink("invoke","_self","POST",inputType),
-                new HyperMediaLink("parent","../")
-        );
+    	List<HyperMediaLink> links = new ArrayList<>();
+    	
+    	links.add(new HyperMediaLink("invoke","_self","POST",inputType));
+    	links.add(new HyperMediaLink("parent","../"));
+    	
+    	if(action.getMetadata().getAssociations().size() > 0)
+    		links.addAll(action.getMetadata().getAssociations());
+
+    	return HypermediaIndex.createContent(links);
     }
 
     @Override

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/HypermediaIndex.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/HypermediaIndex.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import de.thingweb.binding.AbstractRESTListener;
 import de.thingweb.binding.RESTListener;
 import de.thingweb.thing.Content;
+import de.thingweb.thing.HyperMediaLink;
 import de.thingweb.thing.MediaType;
 
 import java.util.Arrays;

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/HypermediaIndex.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/HypermediaIndex.java
@@ -43,8 +43,9 @@ import java.util.Observer;
  *  Resource index for Hypermedia-based navigation (HATEOAS)
  */
 public class HypermediaIndex extends AbstractRESTListener {
+	private static final ObjectMapper mapper = new ObjectMapper();
 
-    private static final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    private static final ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
 
     private Content myContent;
 
@@ -63,7 +64,8 @@ public class HypermediaIndex extends AbstractRESTListener {
     public static Content createContent(List<HyperMediaLink> links) {
         String json = null;
         try {
-            json = ow.writeValueAsString(links);
+        	json = mapper.writeValueAsString(links);
+            //json = ow.writeValueAsString(links);
         } catch (JsonProcessingException e) {
             json = "{ \"error\" : \" " + e.getMessage() + "\"  }";
         }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
@@ -213,9 +213,9 @@ public class MultiBindingThingServer implements ThingServer {
             fullyFormedThingURIs.add(binding.getBase() + Defines.BASE_THING_URL + thingurl);
         }
         
-        thingModel.getThingModel().getMetadata().remove(Metadata.METADATA_ELEMENT_URIS);
+        thingModel.getThingModel().getMetadata().remove(ThingMetadata.METADATA_ELEMENT_URIS);
         for(String uri : fullyFormedThingURIs)
-        	thingModel.getThingModel().getMetadata().add(Metadata.METADATA_ELEMENT_URIS, uri);
+        	thingModel.getThingModel().getMetadata().add(ThingMetadata.METADATA_ELEMENT_URIS, uri);
     }
     
     private void createBinding(ResourceBuilder resources, ServedThing servedThing, boolean isProtected, String thingurl) {

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
@@ -197,9 +197,10 @@ public class MultiBindingThingServer implements ThingServer {
         final HypermediaIndex thingIndex = new HypermediaIndex(thinglinks);*/
 
         
-        List<String> thingURIs = thingModel.getURIs();
+        List<String> thingURIs = thingModel.getURIs(); //The Thing might be specified with part URL (i.e. without protocol binding and base)
         boolean useNameAsURI = (thingURIs == null || thingURIs.size() != m_bindings.size());
         int bindingIndex = 0;
+        List<String> fullyFormedThingURIs = new ArrayList<>();
         // resources
         for (ResourceBuilder binding : m_bindings) {
             // update/create HATEOAS links to things
@@ -209,10 +210,12 @@ public class MultiBindingThingServer implements ThingServer {
             createBinding(binding, thingModel,isProtected, thingurl);
 
             //update metadata
-        	thingModel.getThingModel().getMetadata()
-                    .add("uris", binding.getBase() + Defines.BASE_THING_URL + thingurl);
-
+            fullyFormedThingURIs.add(binding.getBase() + Defines.BASE_THING_URL + thingurl);
         }
+        
+        thingModel.getThingModel().getMetadata().remove(Metadata.METADATA_ELEMENT_URIS);
+        for(String uri : fullyFormedThingURIs)
+        	thingModel.getThingModel().getMetadata().add(Metadata.METADATA_ELEMENT_URIS, uri);
     }
     
     private void createBinding(ResourceBuilder resources, ServedThing servedThing, boolean isProtected, String thingurl) {

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/MultiBindingThingServer.java
@@ -196,26 +196,30 @@ public class MultiBindingThingServer implements ThingServer {
 
         final HypermediaIndex thingIndex = new HypermediaIndex(thinglinks);*/
 
-
+        
+        List<String> thingURIs = thingModel.getURIs();
+        boolean useNameAsURI = (thingURIs == null || thingURIs.size() != m_bindings.size());
+        int bindingIndex = 0;
         // resources
         for (ResourceBuilder binding : m_bindings) {
             // update/create HATEOAS links to things
             binding.newResource(Defines.BASE_THING_URL, RepoRestListener);
-
+            String thingurl = useNameAsURI ? urlize(thingModel.getName()) : thingURIs.get(bindingIndex++);
             //add thing
-            createBinding(binding, thingModel,isProtected);
+            createBinding(binding, thingModel,isProtected, thingurl);
 
             //update metadata
-            thingModel.getThingModel().getMetadata()
-                    .add("uris", binding.getBase() + Defines.BASE_THING_URL + urlize(thingModel.getName()));
+        	thingModel.getThingModel().getMetadata()
+                    .add("uris", binding.getBase() + Defines.BASE_THING_URL + thingurl);
+
         }
     }
     
-    private void createBinding(ResourceBuilder resources, ServedThing servedThing, boolean isProtected) {
+    private void createBinding(ResourceBuilder resources, ServedThing servedThing, boolean isProtected, String thingurl) {
         final Thing thingModel = servedThing.getThingModel();
 
         final Map<String, RESTListener> interactionListeners = new HashMap<>();
-        final String thingurl = Defines.BASE_THING_URL + thingModel.getName().toLowerCase();
+        //final String thingurl = Defines.BASE_THING_URL + thingModel.getName().toLowerCase();
 
         final ThingDescriptionRestListener tdRestListener = new ThingDescriptionRestListener(thingModel);
 

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/PropertyListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/PropertyListener.java
@@ -49,12 +49,14 @@ public class PropertyListener extends AbstractRESTListener implements Observer {
     }
 
     @Override
-    public Content onGet() {
+    public Content onGet() throws Exception {
         if (!property.isReadable()) {
             throw new UnsupportedOperationException();
         }
 
         Object res = servedThing.getProperty(property);
+        if(res instanceof Exception)
+        	throw (Exception)res;
         return ContentHelper.makeJsonValue(res);
 
     }
@@ -66,7 +68,7 @@ public class PropertyListener extends AbstractRESTListener implements Observer {
         }
 
         Object o = ContentHelper.getValueFromJson(data);
-        servedThing.setProperty(property, o);
+        servedThing.updateProperty(property, o);
     }
 
 
@@ -74,5 +76,6 @@ public class PropertyListener extends AbstractRESTListener implements Observer {
     public void update(Observable o, Object arg) {
         log.info("change detected: " + o + " to " + arg);
         setChanged();
+        notifyObservers();
     }
 }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
@@ -28,6 +28,7 @@ package de.thingweb.servient.impl;
 
 import de.thingweb.servient.ThingInterface;
 import de.thingweb.thing.Action;
+import de.thingweb.thing.Metadata;
 import de.thingweb.thing.Property;
 import de.thingweb.thing.Thing;
 import org.slf4j.Logger;
@@ -189,8 +190,8 @@ public class ServedThing implements ThingInterface {
     
     @Override
     public List<String> getURIs(){
-    	if(m_thingModel.getMetadata().contains("hrefs"))
-    		return m_thingModel.getMetadata().getAll("hrefs");
+    	if(m_thingModel.getMetadata().contains(Metadata.METADATA_ELEMENT_URIS))
+    		return m_thingModel.getMetadata().getAll(Metadata.METADATA_ELEMENT_URIS);
     	else
     		return null;
     }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
@@ -33,6 +33,7 @@ import de.thingweb.thing.Thing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -184,6 +185,14 @@ public class ServedThing implements ThingInterface {
     @Override
     public String getName() {
         return m_thingModel.getName();
+    }
+    
+    @Override
+    public List<String> getURIs(){
+    	if(m_thingModel.getMetadata().contains("hrefs"))
+    		return m_thingModel.getMetadata().getAll("hrefs");
+    	else
+    		return null;
     }
     
  // TODO This should perhaps be a generic add interaction. But wait and watch how proposals develop.

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ServedThing.java
@@ -56,7 +56,7 @@ public class ServedThing implements ThingInterface {
     private final Thing m_thingModel;
     private final StateContainer m_stateContainer;
     private Consumer<Object> m_propertyGetCallback;
-    private BiConsumer<Object, Object> m_propertyPutCallback;
+    private BiFunction<Object, Object, Object> m_propertyPutCallback;
     private BiFunction<Object, Object, Object> m_actionPostCallback;
 
     public ServedThing(Thing thing) {
@@ -69,9 +69,12 @@ public class ServedThing implements ThingInterface {
     }
     
     @Override
-    public void updateProperty(Property property, Object value) {
-        if(m_propertyPutCallback != null)
-        	m_propertyPutCallback.accept(property, value);
+    public Object updateProperty(Property property, Object value) {
+        if(m_propertyPutCallback != null){
+        	Object result = m_propertyPutCallback.apply(property, value);
+        	return result;
+        }
+        else return new Exception("No property update handler registered");
     }
 
     @Override
@@ -192,7 +195,7 @@ public class ServedThing implements ThingInterface {
     }
     
     @Override
-    public void onPropertyUpdate(BiConsumer<Object, Object> callback) {
+    public void onPropertyUpdate(BiFunction<Object, Object, Object> callback) {
     	m_propertyPutCallback = callback;
     }
     

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ThingDescriptionRestListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ThingDescriptionRestListener.java
@@ -40,10 +40,10 @@ import java.util.function.Consumer;
  */
 public class ThingDescriptionRestListener extends AbstractRESTListener {
     private final Thing thingModel;
-    private Consumer<Object> m_deleteCallback;
 
     public ThingDescriptionRestListener(Thing thingModel) {
         this.thingModel = thingModel;
+        
     }
 
     @Override
@@ -57,11 +57,9 @@ public class ThingDescriptionRestListener extends AbstractRESTListener {
 
     @Override
 	public void onDelete() {
-    	m_deleteCallback.accept(thingModel);
-		throw new UnsupportedOperationException();
+    	if(thingModel.getDeleteCallback() != null)
+    		thingModel.getDeleteCallback().accept(null);
+    	else
+    		throw new UnsupportedOperationException();
 	}
-    
-    public void addDeleteHandler(Consumer<Object> callback){
-    	m_deleteCallback = callback;
-    }
 }

--- a/thingweb-server/src/main/java/de/thingweb/servient/impl/ThingDescriptionRestListener.java
+++ b/thingweb-server/src/main/java/de/thingweb/servient/impl/ThingDescriptionRestListener.java
@@ -33,12 +33,14 @@ import de.thingweb.thing.MediaType;
 import de.thingweb.thing.Thing;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Created by Johannes on 02.04.2016.
  */
 public class ThingDescriptionRestListener extends AbstractRESTListener {
     private final Thing thingModel;
+    private Consumer<Object> m_deleteCallback;
 
     public ThingDescriptionRestListener(Thing thingModel) {
         this.thingModel = thingModel;
@@ -51,5 +53,15 @@ public class ThingDescriptionRestListener extends AbstractRESTListener {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+	public void onDelete() {
+    	m_deleteCallback.accept(thingModel);
+		throw new UnsupportedOperationException();
+	}
+    
+    public void addDeleteHandler(Consumer<Object> callback){
+    	m_deleteCallback = callback;
     }
 }


### PR DESCRIPTION
Changed ThingInterface to provide a list of URIs representing the Thing. These URIs can be added (optionally) when it is required to have URI something other than the name. For example, to have a structured URL, the thing might need an URL http://server/building_a/room_1/sensor_thing_x. If metadata does not contain explicit "hrefs" for thing then the URIs are constructed out of the name as before.